### PR TITLE
ship LICENSE file in package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE


### PR DESCRIPTION
All derivative copies of pecan-notario are required to contain the disclaimer text within the MIT license (as described in the sentence "The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.") So in order to ease development and distribution of pecan-notario, it makes sense to simply include this text among the packaged files.
