### PR TITLE
exceptions: webob 1.7 compat

### DIFF
--- a/pecan_notario/exceptions.py
+++ b/pecan_notario/exceptions.py
@@ -20,10 +20,12 @@ class JSONValidationException(WSGIHTTPException):
         if self.content_length is not None:
             del self.content_length
         headerlist = list(self.headerlist)
+        charset = 'utf-8'
         content_type = 'application/json'
         body = '{"error": "%s"}' % self.detail
         resp = Response(
             body,
+            charset=charset,
             status=self.status,
             headerlist=headerlist,
             content_type=content_type


### PR DESCRIPTION
WebOb 1.7 raises `TypeError` if we create a Response without a charset kwarg.

~~To work around this, use the text kwarg since the JSON is plaintext.~~ EDIT: not compatible with webob 1.2.3 in RHEL 7. In the new version, I simply set the charset kwarg.